### PR TITLE
Update Polyfill to work with Rails 5.2 RC

### DIFF
--- a/lib/coverhound/dotenv/patch/polyfill/rails_5_0.rb
+++ b/lib/coverhound/dotenv/patch/polyfill/rails_5_0.rb
@@ -31,7 +31,7 @@ module ActiveSupport
 
     attr_reader :content_path, :key_path, :env_key
 
-    def initialize(content_path:, key_path:, env_key:)
+    def initialize(content_path:, key_path:, env_key:, **_)
       @content_path, @key_path = Pathname.new(content_path), Pathname.new(key_path)
       @env_key = env_key
     end


### PR DESCRIPTION
5.2-rc1 is not greater than 5.2, therefore a polyfill is being used.
Adjusting to the new API.